### PR TITLE
Add getUserPlaylists utility function

### DIFF
--- a/src/utils/getUserPlaylists.ts
+++ b/src/utils/getUserPlaylists.ts
@@ -1,0 +1,26 @@
+interface Playlist {
+  id: string;
+  name: string;
+  images: [{ url: string }];
+  snapshot_id: string;
+  uri: string;
+}
+
+const getUserPlaylists = async () => {
+  const response = await fetch('https://api.spotify.com/v1/me/playlists', {
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('token')}`,
+    },
+  });
+  const data = await response.json();
+  const currentUserPlaylists = data.items.map((playlist: Playlist) => ({
+    id: playlist.id,
+    name: playlist.name,
+    image: playlist.images[0].url,
+    snapshot_id: playlist.snapshot_id,
+    uri: playlist.uri,
+  }));
+  return currentUserPlaylists;
+};
+
+export default getUserPlaylists;


### PR DESCRIPTION
Rather than return the entire response this function only returns the items I believe I'll need in order to add further functionality, such as the playlist's name, ID, cover image, snapshot_id and Spotify URI.